### PR TITLE
여러 개의 작은 GPU로 대형 모델을 분할하여 실행할 수 있도록 model parallelism 적용

### DIFF
--- a/kogpt/__main__.py
+++ b/kogpt/__main__.py
@@ -6,7 +6,8 @@ from .inference import KoGPTInference
 
 
 def cli(flags: argparse.Namespace):
-    model = KoGPTInference(flags.model, flags.revision, device=flags.device)
+    model = KoGPTInference(flags.model, flags.revision, device=flags.device,
+                           model_parallel=flags.model_parallel)
 
     while True:
         prompt = input('prompt> ')
@@ -30,6 +31,7 @@ if __name__ == '__main__':
     parser.add_argument('--model', type=str, default='kakaobrain/kogpt', help='huggingface repo (default:kakaobrain/kogpt)')
     parser.add_argument('--revision', type=str, default='KoGPT6B-ryan1.5b-float16', choices=['KoGPT6B-ryan1.5b', 'KoGPT6B-ryan1.5b-float16'], help='(default:KoGPT6B-ryan1.5b-float16)')
     parser.add_argument('--device', type=str, default='cuda', choices=['cpu', 'cuda'], help='(default:cuda)')
+    parser.add_argument('--model_parallel', action='store_true', help='distribute the model across multiple GPUs')
 
     parser.add_argument('-d', '--debug', action='store_true')
     args = parser.parse_args()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-torch~=1.9.0
+torch~=1.12.1
 transformers~=4.12.0


### PR DESCRIPTION
모델을 사용해 보려 했는데 원래 코드 실행 시 GPU가 하나밖에 활용되지 않아서 보통 메모리가 16GB 미만인 컨슈머 레벨 GPU로는 구동이 불가능함을 발견했습니다.
이러한 환경을 위해 모델을 여러 GPU에 나눠서 올릴 수 있는 옵션 `--model_parallel`을 추가한 수정 버전을 만들어 사용했는데, 이를 여기에 공유드립니다. 이 옵션을 주면 10GB 수준의 GPU  4개로 full-precision 모델 구동이 가능합니다.
Possibly fix #19.