### PR TITLE
improve readme model description images dark mode visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@
 
 | Hyperparameter       | Value         |
 |:---------------------|--------------:|
-| <img src="https://render.githubusercontent.com/render/math?math=n_{parameters}"> | 6,166,502,400 |
-| <img src="https://render.githubusercontent.com/render/math?math=n_{layers}">     | 28            |
-| <img src="https://render.githubusercontent.com/render/math?math=d_{model}">      | 4,096         |
-| <img src="https://render.githubusercontent.com/render/math?math=d_{ff}">         | 16,384        |
-| <img src="https://render.githubusercontent.com/render/math?math=n_{heads}">      | 16            |
-| <img src="https://render.githubusercontent.com/render/math?math=d_{head}">       | 256           |
-| <img src="https://render.githubusercontent.com/render/math?math=n_{ctx}">        | 2,048         |
-| <img src="https://render.githubusercontent.com/render/math?math=n_{vocab}">      | 64,512        |
+| $n_{parameters}$     | 6,166,502,400 |
+| $n_{layers}$         | 28            |
+| $d_{model}$          | 4,096         |
+| $d_{ff}$             | 16,384        |
+| $n_{heads}$          | 16            |
+| $d_{head}$           | 256           |
+| $n_{ctx}$            | 2,048         |
+| $n_{vocab}$          | 64,512        |
 | Positional Encoding  | [Rotary Position Embedding (RoPE)](https://arxiv.org/abs/2104.09864) |
 | RoPE Dimensions      | 64            |
 


### PR DESCRIPTION

# Changes 
> Github supports markdown format Latex which doesn't require additional color settings for different github themes. Very useful.
- URL Latex -> Markdown Latex
# Screenshots

### Before ( some github dark themes )

|Dark Dimmed |Dark Tritanopia |
|-|-|
|<img width="400" alt="스크린샷 2023-05-09 16 13 12" src="https://user-images.githubusercontent.com/88357373/237021852-102b4d1b-17cd-4151-b5dd-e73345782c2f.png">|<img width="400" alt="스크린샷 2023-05-09 16 20 05" src="https://user-images.githubusercontent.com/88357373/237023363-2cf414aa-cc29-4e22-9ae7-ccd6e96987c1.png">|

###  After 

|Light|Any Dark|
|-|-|
|![image](https://user-images.githubusercontent.com/88357373/237021551-7586b471-ba0b-4ae0-a6a3-100a1b31ba7e.png)|![image](https://user-images.githubusercontent.com/88357373/237021569-25c45682-1238-4c81-be51-c38ab41c8532.png)|
